### PR TITLE
Minor suggestions

### DIFF
--- a/spring-bus-core/src/main/java/org/springframework/bus/runner/adapter/DownstreamModule.java
+++ b/spring-bus-core/src/main/java/org/springframework/bus/runner/adapter/DownstreamModule.java
@@ -36,6 +36,6 @@ import org.springframework.beans.factory.annotation.Qualifier;
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
 @Documented
-public @interface Upstream {
+public @interface DownstreamModule {
 
 }

--- a/spring-bus-core/src/main/java/org/springframework/bus/runner/adapter/UpstreamModule.java
+++ b/spring-bus-core/src/main/java/org/springframework/bus/runner/adapter/UpstreamModule.java
@@ -26,7 +26,7 @@ import java.lang.annotation.Target;
 import org.springframework.beans.factory.annotation.Qualifier;
 
 /**
- * Qualifier annotation for a bean relating input channels.
+ * Qualifier annotation for a bean relating output channels.
  *
  * @author Dave Syer
  */
@@ -36,6 +36,6 @@ import org.springframework.beans.factory.annotation.Qualifier;
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
 @Documented
-public @interface Downstream {
+public @interface UpstreamModule {
 
 }

--- a/spring-bus-core/src/main/java/org/springframework/bus/runner/adapter/discovery/DiscoveryClientAutoConfiguration.java
+++ b/spring-bus-core/src/main/java/org/springframework/bus/runner/adapter/discovery/DiscoveryClientAutoConfiguration.java
@@ -21,9 +21,9 @@ import javax.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.bus.runner.adapter.ChannelLocator;
-import org.springframework.bus.runner.adapter.Downstream;
+import org.springframework.bus.runner.adapter.DownstreamModule;
 import org.springframework.bus.runner.adapter.MessageBusAdapter;
-import org.springframework.bus.runner.adapter.Upstream;
+import org.springframework.bus.runner.adapter.UpstreamModule;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.cloud.client.discovery.event.HeartbeatEvent;
 import org.springframework.cloud.client.discovery.event.HeartbeatMonitor;
@@ -48,11 +48,11 @@ public class DiscoveryClientAutoConfiguration {
 	private MessageBusAdapter adapter;
 
 	@Autowired(required = false)
-	@Upstream
+	@DownstreamModule
 	private ChannelLocator inputChannelLocator;
 
 	@Autowired(required = false)
-	@Downstream
+	@UpstreamModule
 	private ChannelLocator outputChannelLocator;
 
 	private boolean enabled = false;

--- a/spring-bus-core/src/main/java/org/springframework/bus/runner/config/MessageBusAdapterConfiguration.java
+++ b/spring-bus-core/src/main/java/org/springframework/bus/runner/config/MessageBusAdapterConfiguration.java
@@ -23,6 +23,7 @@ import java.util.Set;
 
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
+
 import org.springframework.aop.framework.ProxyFactory;
 import org.springframework.aop.target.LazyInitTargetSource;
 import org.springframework.beans.factory.BeanFactoryUtils;
@@ -30,11 +31,11 @@ import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.bus.runner.adapter.ChannelLocator;
-import org.springframework.bus.runner.adapter.Upstream;
+import org.springframework.bus.runner.adapter.DownstreamModule;
 import org.springframework.bus.runner.adapter.InputChannelSpec;
 import org.springframework.bus.runner.adapter.MessageBusAdapter;
-import org.springframework.bus.runner.adapter.Downstream;
 import org.springframework.bus.runner.adapter.OutputChannelSpec;
+import org.springframework.bus.runner.adapter.UpstreamModule;
 import org.springframework.bus.runner.endpoint.ChannelsEndpoint;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -60,11 +61,11 @@ public class MessageBusAdapterConfiguration {
 	private ListableBeanFactory beanFactory;
 
 	@Autowired(required=false)
-	@Upstream
+	@DownstreamModule
 	private ChannelLocator inputChannelLocator;
 
 	@Autowired(required=false)
-	@Downstream
+	@UpstreamModule
 	private ChannelLocator outputChannelLocator;
 
 	@Bean

--- a/spring-xd-samples/sink/src/main/resources/bootstrap.yml
+++ b/spring-xd-samples/sink/src/main/resources/bootstrap.yml
@@ -4,6 +4,7 @@ spring:
     group: testtock
     name: logger
     index: 1
+    type: sink
     # uncomment below to have this module consume from a specific partition
     # in the range of 0 to N-1, where N is the upstream module's partitionCount
     #consumerProperties:

--- a/spring-xd-samples/source-xml/src/main/resources/bootstrap.yml
+++ b/spring-xd-samples/source-xml/src/main/resources/bootstrap.yml
@@ -3,3 +3,4 @@ spring:
   bus:
     group: testtock
     name: ticker
+    type: source

--- a/spring-xd-samples/source/src/main/resources/bootstrap.yml
+++ b/spring-xd-samples/source/src/main/resources/bootstrap.yml
@@ -3,6 +3,7 @@ spring:
   bus:
     group: testtock
     name: ticker
+    type: source
     # uncomment below to use the last digit of the seconds as a partition key
     # hashcode(key) % N is then applied with N being the partitionCount value
     # thus, even seconds should go to the 0 queue, odd seconds to the 1 queue

--- a/spring-xd-samples/tap/src/main/resources/bootstrap.yml
+++ b/spring-xd-samples/tap/src/main/resources/bootstrap.yml
@@ -4,6 +4,7 @@ spring:
     group: tocktap
     name: logger
     index: 0
+    type: sink
     tap:
       group: testtock
       name: ticker


### PR DESCRIPTION
- Change the `input/output` channel locator assignment to `DownStream/Upstream` respectively.
  - Previously it was used in reverse.
- Fix `UpStream` module javadoc
- Rename `UpStream`/`DownStream` to `UpStreamModule`/`DownStreamModule`
- Add `spring.bus.type` info the examples (though the type info isn't used yet; would be good to have)
