### PR TITLE
Refactor ChannelSpec

### DIFF
--- a/spring-bus-core/src/main/java/org/springframework/bus/runner/adapter/ChannelSpec.java
+++ b/spring-bus-core/src/main/java/org/springframework/bus/runner/adapter/ChannelSpec.java
@@ -16,38 +16,39 @@
 
 package org.springframework.bus.runner.adapter;
 
-
 /**
  * @author Dave Syer
  * @author Ilayaperumal Gopinathan
  */
-public class OutputChannelSpec extends ChannelSpec {
+public class ChannelSpec {
 
-	private boolean tapped = false;
-	private String tapChannelName;
+	private String name;
+	private String localName;
 
-	protected OutputChannelSpec() {
-		this(DEFAULT_OUTPUT_CHANNEL_NAME);
+	public static final String DEFAULT_INPUT_CHANNEL_NAME = "input";
+
+	public static final String DEFAULT_OUTPUT_CHANNEL_NAME = "output";
+
+	public static final String QUEUE_CHANNEL_PREFIX = "queue";
+
+	protected ChannelSpec() {
+		this(null);
 	}
 
-	public OutputChannelSpec(String localName) {
-		super(localName);
+	public ChannelSpec(String localName) {
+		this.localName = localName;
 	}
 
-	public boolean isTapped() {
-		return this.tapped;
+	public String getName() {
+		return this.name;
 	}
 
-	public void setTapped(boolean tapped) {
-		this.tapped = tapped;
+	public void setName(String name) {
+		this.name = name;
 	}
 
-	public void setTapChannelName(String tapChannelName) {
-		this.tapChannelName = tapChannelName;
-	}
-
-	public String getTapChannelName() {
-		return this.tapChannelName==null ? "" : this.tapChannelName;
+	public String getLocalName() {
+		return this.localName;
 	}
 
 }

--- a/spring-bus-core/src/main/java/org/springframework/bus/runner/adapter/DefaultChannelLocator.java
+++ b/spring-bus-core/src/main/java/org/springframework/bus/runner/adapter/DefaultChannelLocator.java
@@ -33,11 +33,11 @@ public class DefaultChannelLocator implements ChannelLocator {
 
 	@Override
 	public String locate(String name) {
-		String channelName = extractChannelName("input", name, this.module.getInputChannelName());
+		String channelName = extractChannelName(ChannelSpec.DEFAULT_INPUT_CHANNEL_NAME, name, this.module.getInputChannelName());
 		if (channelName!=null) {
 			return channelName;
 		}
-		channelName = extractChannelName("output", name, this.module.getOutputChannelName());
+		channelName = extractChannelName(ChannelSpec.DEFAULT_OUTPUT_CHANNEL_NAME, name, this.module.getOutputChannelName());
 		if (channelName!=null) {
 			return channelName;
 		}
@@ -56,7 +56,7 @@ public class DefaultChannelLocator implements ChannelLocator {
 			if (channelName.contains(":")) {
 				String[] tokens = channelName.split(":", 2);
 				String type = tokens[0];
-				if ("queue".equals(type)) {
+				if (ChannelSpec.QUEUE_CHANNEL_PREFIX.equals(type)) {
 					// omit the type for a queue
 					if (StringUtils.hasText(tokens[1])) {
 						prefix = tokens[1] + ".";

--- a/spring-bus-core/src/main/java/org/springframework/bus/runner/adapter/InputChannelSpec.java
+++ b/spring-bus-core/src/main/java/org/springframework/bus/runner/adapter/InputChannelSpec.java
@@ -18,31 +18,17 @@ package org.springframework.bus.runner.adapter;
 
 /**
  * @author Dave Syer
+ * @author Ilayaperumal Gopinathan
  *
  */
-public class InputChannelSpec {
-
-	private String name;
-	private String localName;
+public class InputChannelSpec extends ChannelSpec {
 
 	protected InputChannelSpec() {
-		this(null);
+		this(DEFAULT_INPUT_CHANNEL_NAME);
 	}
 
 	public InputChannelSpec(String localName) {
-		this.localName = localName;
-	}
-
-	public String getName() {
-		return this.name;
-	}
-
-	public void setName(String name) {
-		this.name = name;
-	}
-
-	public String getLocalName() {
-		return this.localName;
+		super(localName);
 	}
 
 }

--- a/spring-bus-core/src/main/java/org/springframework/bus/runner/adapter/discovery/DiscoveryClientChannelLocator.java
+++ b/spring-bus-core/src/main/java/org/springframework/bus/runner/adapter/discovery/DiscoveryClientChannelLocator.java
@@ -24,9 +24,10 @@ import java.util.Random;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+
 import org.springframework.bus.runner.adapter.ChannelLocator;
+import org.springframework.bus.runner.adapter.ChannelSpec;
 import org.springframework.bus.runner.adapter.ChannelsMetadata;
-import org.springframework.bus.runner.adapter.InputChannelSpec;
 import org.springframework.cloud.client.ServiceInstance;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.web.client.RestOperations;
@@ -66,16 +67,16 @@ public class DiscoveryClientChannelLocator implements ChannelLocator {
 		try {
 			ChannelsMetadata channels = this.restTemplate.getForObject(uri,
 					ChannelsMetadata.class);
-			Collection<? extends InputChannelSpec> specs = Collections.emptySet();
-			if (name.startsWith("input")) {
-				name = name.replace("input", "output");
-				specs = channels.getOutputChannels();
+			Collection<? extends ChannelSpec> specs = Collections.emptySet();
+			if (name.startsWith(ChannelSpec.DEFAULT_INPUT_CHANNEL_NAME)) {
+				name = name.replace(ChannelSpec.DEFAULT_INPUT_CHANNEL_NAME, ChannelSpec.DEFAULT_OUTPUT_CHANNEL_NAME);
+						specs = channels.getOutputChannels();
 			}
-			else if (name.startsWith("output")) {
-				name = name.replace("output", "input");
+			else if (name.startsWith(ChannelSpec.DEFAULT_OUTPUT_CHANNEL_NAME)) {
+				name = name.replace(ChannelSpec.DEFAULT_OUTPUT_CHANNEL_NAME, ChannelSpec.DEFAULT_INPUT_CHANNEL_NAME);
 				specs = channels.getInputChannels();
 			}
-			for (InputChannelSpec spec : specs) {
+			for (ChannelSpec spec : specs) {
 				if (name.equals(spec.getLocalName())) {
 					this.logger.debug("Discovered channel for '" + this.serviceId + "' ("
 							+ name + "=" + spec.getName() + ")");

--- a/spring-bus-core/src/main/java/org/springframework/bus/runner/config/MessageBusAdapterConfiguration.java
+++ b/spring-bus-core/src/main/java/org/springframework/bus/runner/config/MessageBusAdapterConfiguration.java
@@ -30,6 +30,7 @@ import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.bus.runner.adapter.ChannelLocator;
+import org.springframework.bus.runner.adapter.ChannelSpec;
 import org.springframework.bus.runner.adapter.Upstream;
 import org.springframework.bus.runner.adapter.InputChannelSpec;
 import org.springframework.bus.runner.adapter.MessageBusAdapter;
@@ -92,7 +93,7 @@ public class MessageBusAdapterConfiguration {
 		String[] names = BeanFactoryUtils.beanNamesForTypeIncludingAncestors(
 				this.beanFactory, MessageChannel.class);
 		for (String name : names) {
-			if (name.startsWith("output")) {
+			if (name.startsWith(ChannelSpec.DEFAULT_OUTPUT_CHANNEL_NAME)) {
 				channels.add(new OutputChannelSpec(name));
 			}
 		}
@@ -104,7 +105,7 @@ public class MessageBusAdapterConfiguration {
 		String[] names = BeanFactoryUtils.beanNamesForTypeIncludingAncestors(
 				this.beanFactory, MessageChannel.class);
 		for (String name : names) {
-			if (name.startsWith("input")) {
+			if (name.startsWith(ChannelSpec.DEFAULT_INPUT_CHANNEL_NAME)) {
 				channels.add(new InputChannelSpec(name));
 			}
 		}

--- a/spring-bus-core/src/test/java/org/springframework/bus/runner/adapter/DefaultChannelLocatorTests.java
+++ b/spring-bus-core/src/test/java/org/springframework/bus/runner/adapter/DefaultChannelLocatorTests.java
@@ -32,7 +32,7 @@ public class DefaultChannelLocatorTests {
 
 	@Test
 	public void oneOutput() throws Exception {
-		assertEquals("group.0", this.locator.locate("output"));
+		assertEquals("group.0", this.locator.locate(ChannelSpec.DEFAULT_OUTPUT_CHANNEL_NAME));
 	}
 
 	@Test

--- a/spring-bus-core/src/test/java/org/springframework/bus/runner/adapter/DiscoveryClientChannelLocatorTests.java
+++ b/spring-bus-core/src/test/java/org/springframework/bus/runner/adapter/DiscoveryClientChannelLocatorTests.java
@@ -63,18 +63,18 @@ public class DiscoveryClientChannelLocatorTests {
 
 	@Test
 	public void locateInputFromOutput() {
-		OutputChannelSpec output = new OutputChannelSpec("output");
+		OutputChannelSpec output = new OutputChannelSpec();
 		output.setName("foo.0");
 		this.metadata.getOutputChannels().add(output);
-		assertEquals("foo.0", this.locator.locate("input"));
+		assertEquals("foo.0", this.locator.locate(ChannelSpec.DEFAULT_INPUT_CHANNEL_NAME));
 	}
 
 	@Test
 	public void locateOutputFromInput() {
-		InputChannelSpec input = new InputChannelSpec("input");
+		InputChannelSpec input = new InputChannelSpec();
 		input.setName("foo.0");
 		this.metadata.getInputChannels().add(input);
-		assertEquals("foo.0", this.locator.locate("output"));
+		assertEquals("foo.0", this.locator.locate(ChannelSpec.DEFAULT_OUTPUT_CHANNEL_NAME));
 	}
 
 	@SuppressWarnings({ "unchecked" })

--- a/spring-bus-core/src/test/java/org/springframework/bus/runner/config/MessageBusAdapterConfigurationTests.java
+++ b/spring-bus-core/src/test/java/org/springframework/bus/runner/config/MessageBusAdapterConfigurationTests.java
@@ -25,10 +25,11 @@ import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.boot.test.SpringApplicationConfiguration;
-import org.springframework.bus.runner.adapter.InputChannelSpec;
+import org.springframework.bus.runner.adapter.ChannelSpec;
 import org.springframework.bus.runner.adapter.MessageBusAdapter;
 import org.springframework.bus.runner.adapter.OutputChannelSpec;
 import org.springframework.bus.runner.config.MessageBusAdapterConfigurationTests.Empty;
@@ -68,7 +69,7 @@ public class MessageBusAdapterConfigurationTests {
 
 	@Test
 	public void oneOutput() throws Exception {
-		this.context.registerSingleton("output", new DirectChannel());
+		this.context.registerSingleton(ChannelSpec.DEFAULT_OUTPUT_CHANNEL_NAME, new DirectChannel());
 		refresh();
 		Collection<OutputChannelSpec> channels = this.adapter.getChannelsMetadata()
 				.getOutputChannels();
@@ -101,7 +102,7 @@ public class MessageBusAdapterConfigurationTests {
 
 	@Test
 	public void twoOutputsWithQueue() throws Exception {
-		this.context.registerSingleton("output", new DirectChannel());
+		this.context.registerSingleton(ChannelSpec.DEFAULT_OUTPUT_CHANNEL_NAME, new DirectChannel());
 		this.context.registerSingleton("output.queue:foo", new DirectChannel());
 		refresh();
 		Collection<OutputChannelSpec> channels = this.adapter.getChannelsMetadata()
@@ -112,9 +113,9 @@ public class MessageBusAdapterConfigurationTests {
 		assertTrue(names.contains("foo.group.0"));
 	}
 
-	private List<String> getChannelNames(Collection<? extends InputChannelSpec> channels) {
+	private List<String> getChannelNames(Collection<? extends ChannelSpec> channels) {
 		List<String> list = new ArrayList<String>();
-		for (InputChannelSpec spec : channels) {
+		for (ChannelSpec spec : channels) {
 			list.add(spec.getName());
 		}
 		return list;


### PR DESCRIPTION
- Add `ChannelSpec` base class that is inherited by both `InputChannelSpec` and `OutputChannelSpec`
- Moved the channel name constants into `ChannelSpec`
