### PR TITLE
Resolve module location

### DIFF
--- a/spring-bus-core/src/main/java/org/springframework/bus/runner/config/MessageBusProperties.java
+++ b/spring-bus-core/src/main/java/org/springframework/bus/runner/config/MessageBusProperties.java
@@ -27,7 +27,7 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 
 /**
  * @author Dave Syer
- *
+ * @author Ilayaperumal Gopinathan
  */
 @ConfigurationProperties("spring.bus")
 @JsonInclude(Include.NON_DEFAULT)
@@ -44,6 +44,8 @@ public class MessageBusProperties {
 	private String inputChannelName;
 
 	private String type = "processor";
+
+	private String location = "file:.";
 
 	private Properties consumerProperties = new Properties();
 
@@ -118,6 +120,14 @@ public class MessageBusProperties {
 
 	public void setType(String type) {
 		this.type = type;
+	}
+
+	public String getLocation() {
+		return location;
+	}
+
+	public void setLocation(String location) {
+		this.location = location;
 	}
 
 	public Properties getConsumerProperties() {

--- a/spring-xd-runner/src/main/java/org/springframework/bus/xd/bootstrap/ModuleOptionsPropertySourceInitializer.java
+++ b/spring-xd-runner/src/main/java/org/springframework/bus/xd/bootstrap/ModuleOptionsPropertySourceInitializer.java
@@ -80,7 +80,7 @@ public class ModuleOptionsPropertySourceInitializer implements
 
 	private ModuleDefinition getModuleDefinition() {
 		return ModuleDefinitions.simple(module.getName(),
-				ModuleType.valueOf(module.getType()), "file:.");
+				ModuleType.valueOf(module.getType()), module.getLocation());
 	}
 
 	private void insert(ConfigurableEnvironment environment, MapPropertySource source) {

--- a/spring-xd-samples/sink/pom.xml
+++ b/spring-xd-samples/sink/pom.xml
@@ -55,6 +55,17 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<goals>
+							<goal>repackage</goal>
+						</goals>
+						<configuration>
+							<excludeGroupIds>org.springframework.xd</excludeGroupIds>
+							<excludeArtifactIds>spring-xd-runner</excludeArtifactIds>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 		</plugins>
 	</build>

--- a/spring-xd-samples/source-xml/pom.xml
+++ b/spring-xd-samples/source-xml/pom.xml
@@ -49,6 +49,17 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<goals>
+							<goal>repackage</goal>
+						</goals>
+						<configuration>
+							<excludeGroupIds>org.springframework.xd</excludeGroupIds>
+							<excludeArtifactIds>spring-xd-runner</excludeArtifactIds>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 		</plugins>
 	</build>

--- a/spring-xd-samples/source/pom.xml
+++ b/spring-xd-samples/source/pom.xml
@@ -27,10 +27,12 @@
 		<dependency>
 			<groupId>org.springframework.bus</groupId>
 			<artifactId>spring-xd-runner</artifactId>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.xd</groupId>
 			<artifactId>spring-xd-messagebus-redis</artifactId>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
@@ -54,6 +56,17 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<goals>
+							<goal>repackage</goal>
+						</goals>
+						<configuration>
+							<excludeGroupIds>org.springframework.xd</excludeGroupIds>
+							<excludeArtifactIds>spring-xd-runner</excludeArtifactIds>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 		</plugins>
 	</build>

--- a/spring-xd-samples/tap/pom.xml
+++ b/spring-xd-samples/tap/pom.xml
@@ -49,6 +49,17 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<goals>
+							<goal>repackage</goal>
+						</goals>
+						<configuration>
+							<excludeGroupIds>org.springframework.xd,org.springframework.boot</excludeGroupIds>
+							<excludeArtifactIds>spring-xd-runner</excludeArtifactIds>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
Add `spring.bus.location` property 
- This will assign appropirate `location` for the module when its configuration properties are lookedup
  for the module options etc.,

Exclude dependencies in boot repackage
