### PR TITLE
DefaultOptions resolver to use parent CL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,9 +12,9 @@
 	</organization>
     <properties>
       <java.version>1.7</java.version>
-      <spring-boot.version>1.3.0.BUILD-SNAPSHOT</spring-boot.version>
+      <spring-boot.version>1.3.0.M1</spring-boot.version>
       <spring-cloud.version>1.0.3.BUILD-SNAPSHOT</spring-cloud.version>
-      <spring-xd.version>1.2.0.BUILD-SNAPSHOT</spring-xd.version>
+      <spring-xd.version>2.0.0.BUILD-SNAPSHOT</spring-xd.version>
     </properties>
 	<modules>
 		<module>spring-bus-core</module>

--- a/spring-xd-runner/src/main/java/org/springframework/bus/xd/bootstrap/ModuleOptionsPropertySourceInitializer.java
+++ b/spring-xd-runner/src/main/java/org/springframework/bus/xd/bootstrap/ModuleOptionsPropertySourceInitializer.java
@@ -105,7 +105,9 @@ public class ModuleOptionsPropertySourceInitializer implements
 	@Bean
 	// TODO: allow override of this
 	public DefaultModuleOptionsMetadataResolver defaultResolver() {
-		return new DefaultModuleOptionsMetadataResolver();
+		DefaultModuleOptionsMetadataResolver defaultResolver = new DefaultModuleOptionsMetadataResolver();
+		defaultResolver.setUseParentClassLoader(true);
+		return defaultResolver;
 	}
 
 	@ConditionalOnExpression("'${xd.module.config.location:${xd.config.home:}}'!=''")

--- a/spring-xd-runner/src/main/java/org/springframework/bus/xd/bootstrap/ModuleOptionsPropertySourceInitializer.java
+++ b/spring-xd-runner/src/main/java/org/springframework/bus/xd/bootstrap/ModuleOptionsPropertySourceInitializer.java
@@ -106,7 +106,7 @@ public class ModuleOptionsPropertySourceInitializer implements
 	// TODO: allow override of this
 	public DefaultModuleOptionsMetadataResolver defaultResolver() {
 		DefaultModuleOptionsMetadataResolver defaultResolver = new DefaultModuleOptionsMetadataResolver();
-		defaultResolver.setUseParentClassLoader(true);
+		defaultResolver.setShouldCreateModuleClassLoader(false);
 		return defaultResolver;
 	}
 


### PR DESCRIPTION
- This will make sure the options metadata classes are loaded from the
  jars provided in the current classloader as against to the new ParentLastURLClassLoader
  created in XD.
